### PR TITLE
added minimum version for Mac::Pasteboard so as to insure that Clipbo…

### DIFF
--- a/lib/Clipboard/MacPasteboard.pm
+++ b/lib/Clipboard/MacPasteboard.pm
@@ -3,7 +3,7 @@ package Clipboard::MacPasteboard;
 use strict;
 use warnings;
 
-use Mac::Pasteboard;
+use Mac::Pasteboard 0.011;
 
 our $board = Mac::Pasteboard->new();
 $board->set( missing_ok => 1 );


### PR DESCRIPTION
…ard will work on Macos Catalina

Macos Catalina broke copy functionality for Mac::Pastboard versions prior to v0.011.