### PR TITLE
Make problematic t/drivers.t tests author only.

### DIFF
--- a/t/drivers.t
+++ b/t/drivers.t
@@ -35,11 +35,15 @@ eval {
 };
 like($@, qr/is not yet supported/, 'find_driver correctly fails with no DISPLAY');
 
-my $display_drv = do {
-    local %ENV = %ENV;
-    $ENV{DISPLAY} = ':0.0';
-    Clipboard->find_driver('NonOS')
-};
-is $display_drv, 'Xsel', 'driver is Xclip on unknown OS with DISPLAY set';
-is($Clipboard::driver, "Clipboard::$drv", "Actually loaded $drv");
-my $silence_stupid_warning = $Clipboard::driver;
+SKIP: {
+    $ENV{AUTHOR_TESTING}
+	or skip 'Author test', 2;
+    my $display_drv = do {
+	local %ENV = %ENV;
+	$ENV{DISPLAY} = ':0.0';
+	Clipboard->find_driver('NonOS')
+    };
+    is $display_drv, 'Xsel', 'driver is Xclip on unknown OS with DISPLAY set';
+    is($Clipboard::driver, "Clipboard::$drv", "Actually loaded $drv");
+    my $silence_stupid_warning = $Clipboard::driver;
+}


### PR DESCRIPTION
The tests involve driver selection when a display is present and the OS is unrecognized. They fail on the overwhelming majority of CPAN Testers runs under any OS but MSWin32 -- in fact, they die(). this commit skips the problem tests unless $ENV{AUTHOR_TESTING} is true.